### PR TITLE
`gcd`, `gls`, and `git conform cd`

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -68,5 +68,13 @@ pub enum Commands {
         #[arg(short, long, group = "output")]
         #[arg(default_value_t = false)]
         remotes: bool
-    }
+    },
+    /// Change directory to a tracked repository
+    Cd {
+        /// Name of the repository to change to
+        #[arg(required = true)]
+        repo_name: String,
+    },
+    /// Enable CD functionality by adding an alias to your shell configuration
+    EnableCd
 }

--- a/src/core/api.rs
+++ b/src/core/api.rs
@@ -14,9 +14,8 @@ use crate::utils::{
     repos_valid
 };
 
-use std::fs::{self, OpenOptions, File};
+use std::fs::{self, OpenOptions};
 use std::io::Write as _;
-use std::io::Read;
 use std::path::Path;
 use std::env;
 
@@ -230,6 +229,7 @@ pub fn cd_to_repo(repo_name: &str, tracking_file: &TrackingFile) -> Result<Strin
     tracking_file.contents
         .lines()
         .find(|line| Path::new(line).file_name().and_then(|name| name.to_str()) == Some(repo_name))
+        .map(String::from)
         .ok_or_else(|| format!("Repository '{}' not found in tracking file", repo_name))
 }
 

--- a/src/core/api.rs
+++ b/src/core/api.rs
@@ -242,14 +242,24 @@ pub fn enable_cd() -> Result<(), String> {
         (
             format!("{}/.{}rc", home_dir, shell.split('/').last().unwrap()),
             r#"
-gitconform_cd() {
+alias gls='git conform ls'
+alias gcd='git_conform_cd'
+
+git_conform_cd() {
+    if [ -z "$1" ]; then
+        echo "Usage: git_conform_cd <repository-name>"
+        return 1
+    fi
+    
     local repo_path
     repo_path=$(git-conform cd "$1")
-    if [ $? -eq 0 ]; then
-        cd "$repo_path" || return
-    else
-        echo "$repo_path"  # This will print the error message
+    
+    if [ $? -ne 0 ]; then
+        echo "$repo_path"  # This will be the error message
+        return 1
     fi
+    
+    cd "$repo_path" || return 1
 }
 "#
         )

--- a/src/core/api.rs
+++ b/src/core/api.rs
@@ -14,9 +14,11 @@ use crate::utils::{
     repos_valid
 };
 
-use std::fs::{self, OpenOptions};
+use std::fs::{self, OpenOptions, File};
 use std::io::Write as _;
+use std::io::Read;
 use std::path::Path;
+use std::env;
 
 /// Scans only specified directories
 pub fn scan_dirs(mut dirs: Vec<String>, tracking_file: &TrackingFile, scan_hidden: bool) -> Result<(), String> {
@@ -217,5 +219,66 @@ pub async fn check_all(tracking_file: &TrackingFile, flags: &[bool]) -> Result<(
 
     exec_async_check(track_file_lines, flags.to_vec()).await?;
 
+    Ok(())
+}
+
+/// Changes the current directory to the specified repository's path
+pub fn cd_to_repo(repo_name: &str, tracking_file: &TrackingFile) -> Result<(), String> {
+    if tracking_file.contents.is_empty() {
+        return Err(String::from("No repository is being tracked"));
+    }
+
+    let repo_path = tracking_file.contents
+        .lines()
+        .find(|line| Path::new(line).file_name().and_then(|name| name.to_str()) == Some(repo_name))
+        .ok_or_else(|| format!("Repository '{}' not found in tracking file", repo_name))?;
+
+    env::set_current_dir(repo_path)
+        .map_err(|e| format!("Failed to change directory to '{}': {}", repo_path, e))?;
+
+    println!("Changed directory to: {}", repo_path);
+    Ok(())
+}
+
+/// Enables the CD functionality by adding an alias or function to the user's shell configuration
+pub fn enable_cd() -> Result<(), String> {
+    let home_dir = env::var("HOME").map_err(|_| "Failed to get home directory")?;
+    let shell = env::var("SHELL").map_err(|_| "Failed to get current shell")?;
+
+    let (config_file, alias_content) = if shell.ends_with("bash") {
+        (
+            format!("{}/.bashrc", home_dir),
+            "\ngitconform() {\n    if [[ $1 == \"cd\" ]]; then\n        cd \"$(/path/to/git-conform cd \"${@:2}\")\" || return\n    else\n        /path/to/git-conform \"$@\"\n    fi\n}\n"
+        )
+    } else if shell.ends_with("zsh") {
+        (
+            format!("{}/.zshrc", home_dir),
+            "\ngitconform() {\n    if [[ $1 == \"cd\" ]]; then\n        cd \"$(/path/to/git-conform cd \"${@:2}\")\" || return\n    else\n        /path/to/git-conform \"$@\"\n    fi\n}\n"
+        )
+    } else {
+        return Err(format!("Unsupported shell: {}", shell));
+    };
+
+    // Check if the alias already exists
+    let mut file_content = String::new();
+    File::open(&config_file)
+        .and_then(|mut file| file.read_to_string(&mut file_content))
+        .map_err(|e| format!("Failed to read shell config file: {}", e))?;
+
+    if file_content.contains("gitconform()") {
+        println!("CD functionality is already enabled.");
+        return Ok(());
+    }
+
+    // Append the alias to the shell configuration file
+    let mut file = OpenOptions::new()
+        .append(true)
+        .open(&config_file)
+        .map_err(|e| format!("Failed to open shell config file: {}", e))?;
+
+    file.write_all(alias_content.as_bytes())
+        .map_err(|e| format!("Failed to write to shell config file: {}", e))?;
+
+    println!("CD functionality enabled. Please restart your shell or run 'source {}' to apply changes.", config_file);
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -132,8 +132,9 @@ async fn main() {
             }
         },
         Commands::Cd { repo_name } => {
-            if let Err(e) = cd_to_repo(&repo_name, &tracking_file) {
-                handle_error(&e, 7);
+            match cd_to_repo(&repo_name, &tracking_file) {
+                Ok(path) => println!("{}", path),
+                Err(e) => eprintln!("Error: {}", e),
             }
         },
         Commands::EnableCd => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,6 +141,6 @@ async fn main() {
             if let Err(e) = enable_cd() {
                 eprintln!("Error enabling CD functionality: {}", e);
             }
-        }
+        },
     };
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,8 @@ use crate::core::api::{
     scan_all,
     list,
     add,
+    cd_to_repo,
+    enable_cd,
     remove_repos,
     remove_all,
     check_repos,
@@ -127,6 +129,16 @@ async fn main() {
             }
             else if let Err(e) = check_repos(repos.to_owned(), &[*status, *remotes]).await {
                 handle_error(&e, 6);
+            }
+        },
+        Commands::Cd { repo_name } => {
+            if let Err(e) = cd_to_repo(&repo_name, &tracking_file) {
+                handle_error(&e, 7);
+            }
+        },
+        Commands::EnableCd => {
+            if let Err(e) = enable_cd() {
+                handle_error(&e, 8);
             }
         }
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -139,7 +139,7 @@ async fn main() {
         },
         Commands::EnableCd => {
             if let Err(e) = enable_cd() {
-                handle_error(&e, 8);
+                eprintln!("Error enabling CD functionality: {}", e);
             }
         }
     };

--- a/tests/cd.rs
+++ b/tests/cd.rs
@@ -1,64 +1,26 @@
-use git_conform::core::api::{add, cd_to_repo};
-use std::fs;
-use std::path::Path;
-use std::process::Command;
-use serial_test::serial;
-
 mod common;
 
-#[test]
-fn case_cd_fake() {
-    let (_home_dir, tracking_file, tests_dir) = common::setup().unwrap();
-    
-    // Try to cd to a non-existent repository
-    let fake_repo = "fake_repo";
-    assert_eq!(
-        cd_to_repo(fake_repo, &tracking_file),
-        Err(String::from("No repository is being tracked"))
-    );
-
-    common::cleanup(&tests_dir).unwrap();
-}
-
-#[test]
-fn case_cd_empty_tracking_file() {
-    let (_home_dir, tracking_file, tests_dir) = common::setup().unwrap();
-    
-    // Ensure the tracking file is empty
-    fs::write(&tracking_file.path, "").unwrap();
-
-    // Try to cd to any repository with an empty tracking file
-    let repo_name = "any_repo";
-    assert_eq!(
-        cd_to_repo(repo_name, &tracking_file),
-        Err(String::from("No repository is being tracked"))
-    );
-
-    common::cleanup(&tests_dir).unwrap();
-}
+use git_conform::core::api::{add, cd_to_repo};
+use git_conform::utils::TrackingFile;
+use std::fs;
+use std::path::Path;
+use serial_test::serial;
 
 #[test]
 #[serial]
-fn case_cd_real() {
-    let (_home_dir, tracking_file, tests_dir) = common::setup().unwrap();
-    // Remove the tracking file if it already exists
-    if Path::new(tracking_file.path.as_str()).try_exists().unwrap() {
-        fs::remove_file(&tracking_file.path).unwrap();
-    }
+fn test_cd_to_existing_repo() {
+    let (_home_dir, mut tracking_file, tests_dir) = common::setup().unwrap();
     
     // Add some repositories to the tracking file
-    let mut repos: Vec<String> = Vec::new();
-    for n in 1..=3 {
-        let repo_path = format!("{}/repo{}", tests_dir, n);
-        fs::create_dir_all(&repo_path).unwrap();
-        // Initialize git repository
-        Command::new("git")
-            .args(&["init", &repo_path])
-            .output()
-            .expect("Failed to initialize git repository");
-        repos.push(repo_path);
-    }
-    assert_eq!(add(repos, &tracking_file), Ok(()));
+    let repos = vec![
+        format!("{}/repo1", tests_dir),
+        format!("{}/repo2", tests_dir),
+        format!("{}/repo3", tests_dir),
+    ];
+    assert!(add(repos.clone(), &tracking_file).is_ok());
+
+    // Manually update tracking_file contents
+    tracking_file.contents = repos.join("\n");
 
     // Test cd_to_repo for each added repository
     for n in 1..=3 {
@@ -72,34 +34,100 @@ fn case_cd_real() {
 
 #[test]
 #[serial]
-fn case_cd_multiple_repos_same_name() {
-    let (_home_dir, tracking_file, tests_dir) = common::setup().unwrap();
-    // Remove the tracking file if it already exists
-    if Path::new(tracking_file.path.as_str()).try_exists().unwrap() {
-        fs::remove_file(&tracking_file.path).unwrap();
-    }
+fn test_cd_to_nonexistent_repo() {
+    let (_home_dir, mut tracking_file, tests_dir) = common::setup().unwrap();
     
-    // Create directories and initialize git repos
-    for dir in ["dir1", "dir2"].iter() {
-        let repo_path = format!("{}/{}/repo1", tests_dir, dir);
-        fs::create_dir_all(&repo_path).unwrap();
-        Command::new("git")
-            .args(&["init", &repo_path])
-            .output()
-            .expect("Failed to initialize git repository");
-    }
+    // Add a repository to ensure the tracking file is not empty
+    let repo = format!("{}/repo1", tests_dir);
+    assert!(add(vec![repo.clone()], &tracking_file).is_ok());
+
+    // Manually update tracking_file contents
+    tracking_file.contents = repo;
+
+    // Try to cd to a non-existent repository
+    let fake_repo = "fake_repo";
+    assert_eq!(
+        cd_to_repo(fake_repo, &tracking_file),
+        Err(format!("Repository '{}' not found in tracking file", fake_repo))
+    );
+
+    common::cleanup(&tests_dir).unwrap();
+}
+
+#[test]
+#[serial]
+fn test_cd_with_empty_tracking_file() {
+    let (_home_dir, tracking_file, tests_dir) = common::setup().unwrap();
+    
+    // Ensure the tracking file is empty (this is already the case after setup)
+
+    // Try to cd to any repository with an empty tracking file
+    let repo_name = "any_repo";
+    assert_eq!(
+        cd_to_repo(repo_name, &tracking_file),
+        Err(String::from("No repository is being tracked"))
+    );
+
+    common::cleanup(&tests_dir).unwrap();
+}
+
+#[test]
+#[serial]
+fn test_cd_to_hidden_repo() {
+    let (_home_dir, mut tracking_file, tests_dir) = common::setup().unwrap();
+    
+    // Add a hidden repository to the tracking file
+    let hidden_repo = format!("{}/.hidden/repo1", tests_dir);
+    assert!(add(vec![hidden_repo.clone()], &tracking_file).is_ok());
+
+    // Manually update tracking_file contents
+    tracking_file.contents = hidden_repo.clone();
+
+    // Test cd_to_repo for the hidden repository
+    assert_eq!(cd_to_repo("repo1", &tracking_file), Ok(hidden_repo));
+
+    common::cleanup(&tests_dir).unwrap();
+}
+
+#[test]
+#[serial]
+fn test_cd_multiple_repos_same_name() {
+    let (_home_dir, mut tracking_file, tests_dir) = common::setup().unwrap();
     
     // Add repositories with the same name in different directories
     let repos = vec![
-        format!("{}/dir1/repo1", tests_dir),
-        format!("{}/dir2/repo1", tests_dir),
+        format!("{}/repo1", tests_dir),
+        format!("{}/.hidden/repo1", tests_dir),
     ];
-    assert_eq!(add(repos, &tracking_file), Ok(()));
+    assert!(add(repos.clone(), &tracking_file).is_ok());
+
+    // Manually update tracking_file contents
+    tracking_file.contents = repos.join("\n");
 
     // Test cd_to_repo with a repo name that exists multiple times
-    let repo_name = "repo1";
-    let expected_path = format!("{}/dir1/repo1", tests_dir);
-    assert_eq!(cd_to_repo(repo_name, &tracking_file), Ok(expected_path));
+    let expected_path = format!("{}/repo1", tests_dir);
+    assert_eq!(cd_to_repo("repo1", &tracking_file), Ok(expected_path));
+
+    common::cleanup(&tests_dir).unwrap();
+}
+
+#[test]
+#[serial]
+fn test_cd_to_fake_repo() {
+    let (_home_dir, mut tracking_file, tests_dir) = common::setup().unwrap();
+    
+    // Add a real repository to ensure the tracking file is not empty
+    let real_repo = format!("{}/repo1", tests_dir);
+    assert!(add(vec![real_repo.clone()], &tracking_file).is_ok());
+
+    // Manually update tracking_file contents
+    tracking_file.contents = real_repo;
+
+    // Try to cd to a fake repository
+    assert_eq!(
+        cd_to_repo("fake_repo1", &tracking_file),
+        Err(String::from("Repository 'fake_repo1' not found in tracking file"))
+    );
 
     common::cleanup(&tests_dir).unwrap();
 }

--- a/tests/cd.rs
+++ b/tests/cd.rs
@@ -1,0 +1,89 @@
+mod common;
+
+use git_conform::core::api::{add, cd_to_repo};
+use std::fs;
+use std::path::Path;
+use std::env;
+use serial_test::serial;
+
+#[test]
+#[serial]
+fn case_cd_real() {
+    let (_home_dir, tracking_file, tests_dir) = common::setup().unwrap();
+    // Remove the tracking file if it already exists
+    if Path::new(tracking_file.path.as_str()).try_exists().unwrap() {
+        fs::remove_file(&tracking_file.path).unwrap();
+    }
+    
+    // Add some repositories to the tracking file
+    let mut repos: Vec<String> = Vec::new();
+    for n in 1..=3 {
+        repos.push(format!("{}/repo{}", tests_dir, n));
+    }
+    assert_eq!(add(repos, &tracking_file), Ok(()));
+
+    // Test cd_to_repo for each added repository
+    for n in 1..=3 {
+        let repo_name = format!("repo{}", n);
+        assert_eq!(cd_to_repo(&repo_name, &tracking_file), Ok(()));
+        assert_eq!(env::current_dir().unwrap(), Path::new(&format!("{}/repo{}", tests_dir, n)));
+    }
+
+    common::cleanup(&tests_dir).unwrap();
+}
+
+#[test]
+fn case_cd_fake() {
+    let (_home_dir, tracking_file, tests_dir) = common::setup().unwrap();
+    
+    // Try to cd to a non-existent repository
+    let fake_repo = "fake_repo";
+    assert_eq!(
+        cd_to_repo(fake_repo, &tracking_file),
+        Err(format!("Repository '{}' not found in tracking file", fake_repo))
+    );
+
+    common::cleanup(&tests_dir).unwrap();
+}
+
+#[test]
+fn case_cd_empty_tracking_file() {
+    let (_home_dir, tracking_file, tests_dir) = common::setup().unwrap();
+    
+    // Ensure the tracking file is empty
+    fs::write(&tracking_file.path, "").unwrap();
+
+    // Try to cd to any repository with an empty tracking file
+    let repo_name = "any_repo";
+    assert_eq!(
+        cd_to_repo(repo_name, &tracking_file),
+        Err(String::from("No repository is being tracked"))
+    );
+
+    common::cleanup(&tests_dir).unwrap();
+}
+
+#[test]
+#[serial]
+fn case_cd_multiple_repos_same_name() {
+    let (_home_dir, tracking_file, tests_dir) = common::setup().unwrap();
+    // Remove the tracking file if it already exists
+    if Path::new(tracking_file.path.as_str()).try_exists().unwrap() {
+        fs::remove_file(&tracking_file.path).unwrap();
+    }
+    
+    // Add repositories with the same name in different directories
+    let repos = vec![
+        format!("{}/dir1/repo1", tests_dir),
+        format!("{}/dir2/repo1", tests_dir),
+    ];
+    assert_eq!(add(repos, &tracking_file), Ok(()));
+
+    // Test cd_to_repo with a repo name that exists multiple times
+    let repo_name = "repo1";
+    assert_eq!(cd_to_repo(repo_name, &tracking_file), Ok(()));
+    // It should change to the first occurrence in the tracking file
+    assert_eq!(env::current_dir().unwrap(), Path::new(&format!("{}/dir1/repo1", tests_dir)));
+
+    common::cleanup(&tests_dir).unwrap();
+}

--- a/tests/cd.rs
+++ b/tests/cd.rs
@@ -7,6 +7,37 @@ use std::env;
 use serial_test::serial;
 
 #[test]
+fn case_cd_fake() {
+    let (_home_dir, tracking_file, tests_dir) = common::setup().unwrap();
+    
+    // Try to cd to a non-existent repository
+    let fake_repo = "fake_repo";
+    assert_eq!(
+        cd_to_repo(fake_repo, &tracking_file),
+        Err(String::from("No repository is being tracked"))
+    );
+
+    common::cleanup(&tests_dir).unwrap();
+}
+
+#[test]
+fn case_cd_empty_tracking_file() {
+    let (_home_dir, tracking_file, tests_dir) = common::setup().unwrap();
+    
+    // Ensure the tracking file is empty
+    fs::write(&tracking_file.path, "").unwrap();
+
+    // Try to cd to any repository with an empty tracking file
+    let repo_name = "any_repo";
+    assert_eq!(
+        cd_to_repo(repo_name, &tracking_file),
+        Err(String::from("No repository is being tracked"))
+    );
+
+    common::cleanup(&tests_dir).unwrap();
+}
+
+#[test]
 #[serial]
 fn case_cd_real() {
     let (_home_dir, tracking_file, tests_dir) = common::setup().unwrap();
@@ -33,43 +64,19 @@ fn case_cd_real() {
 }
 
 #[test]
-fn case_cd_fake() {
-    let (_home_dir, tracking_file, tests_dir) = common::setup().unwrap();
-    
-    // Try to cd to a non-existent repository
-    let fake_repo = "fake_repo";
-    assert_eq!(
-        cd_to_repo(fake_repo, &tracking_file),
-        Err(format!("Repository '{}' not found in tracking file", fake_repo))
-    );
-
-    common::cleanup(&tests_dir).unwrap();
-}
-
-#[test]
-fn case_cd_empty_tracking_file() {
-    let (_home_dir, tracking_file, tests_dir) = common::setup().unwrap();
-    
-    // Ensure the tracking file is empty
-    fs::write(&tracking_file.path, "").unwrap();
-
-    // Try to cd to any repository with an empty tracking file
-    let repo_name = "any_repo";
-    assert_eq!(
-        cd_to_repo(repo_name, &tracking_file),
-        Err(String::from("No repository is being tracked"))
-    );
-
-    common::cleanup(&tests_dir).unwrap();
-}
-
-#[test]
 #[serial]
 fn case_cd_multiple_repos_same_name() {
     let (_home_dir, tracking_file, tests_dir) = common::setup().unwrap();
     // Remove the tracking file if it already exists
     if Path::new(tracking_file.path.as_str()).try_exists().unwrap() {
         fs::remove_file(&tracking_file.path).unwrap();
+    }
+    
+    // Create directories and initialize git repos
+    for dir in ["dir1", "dir2"].iter() {
+        let repo_path = format!("{}/{}/repo1", tests_dir, dir);
+        fs::create_dir_all(&repo_path).unwrap();
+        git2::Repository::init(&repo_path).unwrap();
     }
     
     // Add repositories with the same name in different directories

--- a/tests/cd.rs
+++ b/tests/cd.rs
@@ -1,10 +1,10 @@
-mod common;
-
 use git_conform::core::api::{add, cd_to_repo};
 use std::fs;
 use std::path::Path;
-use std::env;
+use std::process::Command;
 use serial_test::serial;
+
+mod common;
 
 #[test]
 fn case_cd_fake() {
@@ -49,15 +49,22 @@ fn case_cd_real() {
     // Add some repositories to the tracking file
     let mut repos: Vec<String> = Vec::new();
     for n in 1..=3 {
-        repos.push(format!("{}/repo{}", tests_dir, n));
+        let repo_path = format!("{}/repo{}", tests_dir, n);
+        fs::create_dir_all(&repo_path).unwrap();
+        // Initialize git repository
+        Command::new("git")
+            .args(&["init", &repo_path])
+            .output()
+            .expect("Failed to initialize git repository");
+        repos.push(repo_path);
     }
     assert_eq!(add(repos, &tracking_file), Ok(()));
 
     // Test cd_to_repo for each added repository
     for n in 1..=3 {
         let repo_name = format!("repo{}", n);
-        assert_eq!(cd_to_repo(&repo_name, &tracking_file), Ok(()));
-        assert_eq!(env::current_dir().unwrap(), Path::new(&format!("{}/repo{}", tests_dir, n)));
+        let expected_path = format!("{}/repo{}", tests_dir, n);
+        assert_eq!(cd_to_repo(&repo_name, &tracking_file), Ok(expected_path));
     }
 
     common::cleanup(&tests_dir).unwrap();
@@ -76,7 +83,10 @@ fn case_cd_multiple_repos_same_name() {
     for dir in ["dir1", "dir2"].iter() {
         let repo_path = format!("{}/{}/repo1", tests_dir, dir);
         fs::create_dir_all(&repo_path).unwrap();
-        git2::Repository::init(&repo_path).unwrap();
+        Command::new("git")
+            .args(&["init", &repo_path])
+            .output()
+            .expect("Failed to initialize git repository");
     }
     
     // Add repositories with the same name in different directories
@@ -88,9 +98,8 @@ fn case_cd_multiple_repos_same_name() {
 
     // Test cd_to_repo with a repo name that exists multiple times
     let repo_name = "repo1";
-    assert_eq!(cd_to_repo(repo_name, &tracking_file), Ok(()));
-    // It should change to the first occurrence in the tracking file
-    assert_eq!(env::current_dir().unwrap(), Path::new(&format!("{}/dir1/repo1", tests_dir)));
+    let expected_path = format!("{}/dir1/repo1", tests_dir);
+    assert_eq!(cd_to_repo(repo_name, &tracking_file), Ok(expected_path));
 
     common::cleanup(&tests_dir).unwrap();
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -108,3 +108,9 @@ pub fn setup() -> Result<(String, TrackingFile, String), String> {
 
     Ok((home_dir, tracking_file, tests_dir))
 }
+
+pub fn cleanup(tests_dir: &str) -> Result<(), String> {
+    fs::remove_dir_all(tests_dir)
+        .map_err(|e| format!("Failed to remove test directory: {}", e))?;
+    Ok(())
+}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** 
Feature

* **What is the current behavior?** (You can also link to an open issue here)
Feature does not exist

* **What is the new behavior (if this is a feature change)?**
`gcd` - allows the user to instantly cd into any git repo in the tracking file by name
`gls` - a shortcut to listing repos

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No breaking changes

* **Other information**:
Tests added for the gcd command

The command itself is two parts;
- `gcd`: is a shell alias pointing to a function that changes the path of the user (it is not possible to implement this functionality in Rust itself)
- `git conform cd`: simply prints the path to a repo since rust itself cannot CD the user's shell