### PR TITLE
Add result messages to the `scan` command

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -34,7 +34,11 @@ pub enum Commands {
         /// Allow scanning hidden directories
         #[arg(long)]
         #[arg(default_value_t = false)]
-        hidden: bool
+        hidden: bool,
+        /// Suppress information messages
+        #[arg(short, long)]
+        #[arg(default_value_t = false)]
+        quiet: bool
     },
     /// Print the list of tracked repositories
     List,

--- a/src/core/api.rs
+++ b/src/core/api.rs
@@ -19,7 +19,7 @@ use std::io::Write as _;
 use std::path::Path;
 
 /// Scans only specified directories
-pub fn scan_dirs(mut dirs: Vec<String>, tracking_file: &TrackingFile, scan_hidden: bool) -> Result<(), String> {
+pub fn scan_dirs(mut dirs: Vec<String>, tracking_file: &TrackingFile, scan_hidden: bool) -> Result<String, String> {
     // Remove duplicates
     dirs.sort_unstable();
     dirs.dedup();
@@ -68,16 +68,12 @@ pub fn scan_dirs(mut dirs: Vec<String>, tracking_file: &TrackingFile, scan_hidde
         return Err(String::from("Directories validation failed"));
     }
 
-    search_for_repos(dirs.as_slice(), tracking_file, scan_hidden)?;
-
-    Ok(())
+    Ok(search_for_repos(dirs.as_slice(), tracking_file, scan_hidden)?)
 }
 
 /// Scans all directories in user's /home
-pub fn scan_all(home_dir: String, tracking_file: &TrackingFile, scan_hidden: bool) -> Result<(), String> {
-    search_for_repos(&[home_dir], tracking_file, scan_hidden)?;
-
-    Ok(())
+pub fn scan_all(home_dir: String, tracking_file: &TrackingFile, scan_hidden: bool) -> Result<String, String> {
+    Ok(search_for_repos(&[home_dir], tracking_file, scan_hidden)?)
 }
 
 /// Prints the paths of all tracked git repositories to the standard output

--- a/src/core/backend.rs
+++ b/src/core/backend.rs
@@ -21,7 +21,9 @@ use indicatif::{MultiProgress, ProgressBar};
 
 // Searches recursively in dirs for untracked git repositories and automatically adds them to the tracking file
 #[allow(clippy::redundant_closure_for_method_calls)]
-pub fn search_for_repos(dirs: &[String], tracking_file: &TrackingFile, scan_hidden: bool) -> Result<(), String> {
+pub fn search_for_repos(dirs: &[String], tracking_file: &TrackingFile, scan_hidden: bool) -> Result<String, String> {
+    let mut repos = String::new();
+
     // Open/create the tracking file for writing
     let track_file = OpenOptions::new()
         .create(true)
@@ -36,7 +38,10 @@ pub fn search_for_repos(dirs: &[String], tracking_file: &TrackingFile, scan_hidd
                 .same_file_system(true)
                 .into_iter()
                 .filter_map(|n| n.ok()) {
-                    search_core(&entry, &track_file, tracking_file.path.as_str(), tracking_file.contents.as_str())?;
+                    match search_core(&entry, &track_file, tracking_file.path.as_str(), tracking_file.contents.as_str()) {
+                        Ok(s) => repos.push_str(&s),
+                        Err(e) => return Err(e)
+                    }
             }
         }
     }
@@ -48,23 +53,28 @@ pub fn search_for_repos(dirs: &[String], tracking_file: &TrackingFile, scan_hidd
                 .into_iter()
                 .filter_entry(|n| !entry_is_hidden(n))
                 .filter_map(|n| n.ok()) {
-                    search_core(&entry, &track_file, tracking_file.path.as_str(), tracking_file.contents.as_str())?;
+                    match search_core(&entry, &track_file, tracking_file.path.as_str(), tracking_file.contents.as_str()) {
+                        Ok(s) => repos.push_str(&s),
+                        Err(e) => return Err(e)
+                    }
             }
         }
     }
 
-    Ok(())
+    Ok(repos)
 }
 
 // Core functionality of the `search_for_repos` function
-fn search_core(entry: &DirEntry, mut track_file: &File, track_file_path: &str, track_file_contents: &str) -> Result<(), String> {
+fn search_core(entry: &DirEntry, mut track_file: &File, track_file_path: &str, track_file_contents: &str) -> Result<String, String> {
+    let mut repo = String::new();
+
     // Check if the path contains .git directory
     if let Some(path) = entry.path().to_str() {
         if let Some(repo_path) = path.strip_suffix("/.git") {
             // Check if the tracking file already
             // contains the git repository path
             if repo_is_tracked(repo_path, track_file_contents) {
-                return Ok(())
+                return Ok(repo)
             }
 
             // Check if the path is in fact a git repository
@@ -75,6 +85,8 @@ fn search_core(entry: &DirEntry, mut track_file: &File, track_file_path: &str, t
                         track_file.write_all(
                             format!("{repo_path}\n").as_bytes())
                             .map_err(|e| format!("{track_file_path}: {e}"))?;
+                        
+                        repo = format!("{repo_path}\n");
                     }
                 },
                 Err(e) => return Err(e)
@@ -82,7 +94,7 @@ fn search_core(entry: &DirEntry, mut track_file: &File, track_file_path: &str, t
         }
     }
 
-    Ok(())
+    Ok(repo)
 }
 
 // Checks if a given entry is a hidden directory

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,7 +89,7 @@ async fn main() {
 
     // Handle command-line interactions
     match Cli::parse().get_command() {
-        Commands::Scan { dirs, all, hidden} => {
+        Commands::Scan { dirs, all, hidden, quiet} => {
             let result: Result<String, String>;
 
             if *all {
@@ -101,12 +101,14 @@ async fn main() {
 
             match result {
                 Ok(repos) => {
-                    if repos.is_empty() {
-                        println!("{APP_NAME}: No untracked repositories found");
-                    }
-                    else {
-                        println!("{APP_NAME}: Found untracked repositories:\n");
-                        print!("{repos}");
+                    if !*quiet {
+                        if repos.is_empty() {
+                            println!("{APP_NAME}: No untracked repositories found");
+                        }
+                        else {
+                            println!("{APP_NAME}: Found untracked repositories:\n");
+                            print!("{repos}");
+                        }
                     }
                 },
                 Err(e) => handle_error(&e, 2)

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,33 +90,26 @@ async fn main() {
     // Handle command-line interactions
     match Cli::parse().get_command() {
         Commands::Scan { dirs, all, hidden} => {
+            let result: Result<String, String>;
+
             if *all {
-                match scan_all(home_dir, &tracking_file, *hidden) {
-                    Ok(s) => {
-                        if s.is_empty() {
-                            println!("{APP_NAME}: No untracked repositories found");
-                        }
-                        else {
-                            println!("{APP_NAME}: Found untracked repositories:\n");
-                            print!("{s}");
-                        }
-                    },
-                    Err(e) => handle_error(&e, 2)
-                }
+                result = scan_all(home_dir, &tracking_file, *hidden);
             }
             else {
-                match scan_dirs(dirs.to_owned(), &tracking_file, *hidden) {
-                    Ok(s) => {
-                        if s.is_empty() {
-                            println!("{APP_NAME}: No untracked repositories found");
-                        }
-                        else {
-                            println!("{APP_NAME}: Found untracked repositories:\n");
-                            print!("{s}");
-                        }
-                    },
-                    Err(e) => handle_error(&e, 2)
-                }
+                result = scan_dirs(dirs.to_owned(), &tracking_file, *hidden);
+            }
+
+            match result {
+                Ok(s) => {
+                    if s.is_empty() {
+                        println!("{APP_NAME}: No untracked repositories found");
+                    }
+                    else {
+                        println!("{APP_NAME}: Found untracked repositories:\n");
+                        print!("{s}");
+                    }
+                },
+                Err(e) => handle_error(&e, 2)
             }
         },
         Commands::List => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,12 +91,32 @@ async fn main() {
     match Cli::parse().get_command() {
         Commands::Scan { dirs, all, hidden} => {
             if *all {
-                if let Err(e) = scan_all(home_dir, &tracking_file, *hidden) {
-                    handle_error(&e, 2);
+                match scan_all(home_dir, &tracking_file, *hidden) {
+                    Ok(s) => {
+                        if s.is_empty() {
+                            println!("{APP_NAME}: No untracked repositories found");
+                        }
+                        else {
+                            println!("{APP_NAME}: Found untracked repositories:\n");
+                            print!("{s}");
+                        }
+                    },
+                    Err(e) => handle_error(&e, 2)
                 }
             }
-            else if let Err(e) = scan_dirs(dirs.to_owned(), &tracking_file, *hidden) {
-                handle_error(&e, 2);
+            else {
+                match scan_dirs(dirs.to_owned(), &tracking_file, *hidden) {
+                    Ok(s) => {
+                        if s.is_empty() {
+                            println!("{APP_NAME}: No untracked repositories found");
+                        }
+                        else {
+                            println!("{APP_NAME}: Found untracked repositories:\n");
+                            print!("{s}");
+                        }
+                    },
+                    Err(e) => handle_error(&e, 2)
+                }
             }
         },
         Commands::List => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,13 +100,13 @@ async fn main() {
             }
 
             match result {
-                Ok(s) => {
-                    if s.is_empty() {
+                Ok(repos) => {
+                    if repos.is_empty() {
                         println!("{APP_NAME}: No untracked repositories found");
                     }
                     else {
                         println!("{APP_NAME}: Found untracked repositories:\n");
-                        print!("{s}");
+                        print!("{repos}");
                     }
                 },
                 Err(e) => handle_error(&e, 2)

--- a/tests/scan.rs
+++ b/tests/scan.rs
@@ -18,7 +18,7 @@ fn case_scan_dirs_hidden() {
     }
 
     // The function executes without errors
-    assert_eq!(scan_dirs(vec![tests_dir.to_string()], &tracking_file, true), Ok(()));
+    assert!(scan_dirs(vec![tests_dir.to_string()], &tracking_file, true).is_ok());
 
     // Read the updated tracking file
     let track_file_up = fs::read_to_string(tracking_file.path).unwrap();
@@ -61,7 +61,7 @@ fn case_scan_dirs_no_hidden() {
     }
 
     // The function executes without errors
-    assert_eq!(scan_dirs(vec![tests_dir.to_string()], &tracking_file, false), Ok(()));
+    assert!(scan_dirs(vec![tests_dir.to_string()], &tracking_file, false).is_ok());
 
     // Read the updated tracking file
     let track_file_up = fs::read_to_string(tracking_file.path).unwrap();
@@ -132,7 +132,7 @@ fn case_scan_all() {
     }
 
     // The function executes without errors
-    assert_eq!(scan_all(home_dir, &tracking_file, true), Ok(()));
+    assert!(scan_all(home_dir, &tracking_file, true).is_ok());
 
     // Read the updated tracking file
     let track_file_up = fs::read_to_string(tracking_file.path).unwrap();

--- a/tests/scan.rs
+++ b/tests/scan.rs
@@ -164,3 +164,92 @@ fn case_scan_all() {
     }
 }
 
+#[test]
+#[serial]
+fn case_scan_dirs_found_new() {
+    let (_home_dir, tracking_file, tests_dir) = common::setup().unwrap();
+
+    // Remove the tracking file if it already exists
+    if Path::new(tracking_file.path.as_str()).try_exists().unwrap() {
+        fs::remove_file(&tracking_file.path).unwrap();
+    }
+
+    // The returned string contains newly found repositories 
+    
+    let repos = scan_dirs(vec![tests_dir.to_string()], &tracking_file, true).unwrap();
+
+    for n in 1..=3 {
+        assert!(repos.contains(
+            format!("{tests_dir}/repo{n}").as_str()
+        ));
+        assert!(repos.contains(
+            format!("{tests_dir}/.hidden/repo{n}").as_str()
+        ));
+    }
+}
+
+#[test]
+#[serial]
+fn case_scan_dirs_found_none() {
+    let (_home_dir, mut tracking_file, tests_dir) = common::setup().unwrap();
+
+    // Remove the tracking file if it already exists
+    if Path::new(tracking_file.path.as_str()).try_exists().unwrap() {
+        fs::remove_file(&tracking_file.path).unwrap();
+    }
+
+    let dirs = vec![tests_dir.to_string()];
+
+    // Create and populate the tracking file 
+    scan_dirs(dirs.clone(), &tracking_file, true).unwrap();
+
+    // Update the tracking file contents
+    tracking_file.contents = fs::read_to_string(&tracking_file.path).unwrap();
+
+    // The returned string doesn't contain any repositories
+    assert!(scan_dirs(dirs, &tracking_file, true).unwrap().is_empty());
+}
+
+#[test]
+#[serial]
+fn case_scan_all_found_new() {
+    let (home_dir, tracking_file, tests_dir) = common::setup().unwrap();
+
+    // Remove the tracking file if it already exists
+    if Path::new(tracking_file.path.as_str()).try_exists().unwrap() {
+        fs::remove_file(&tracking_file.path).unwrap();
+    }
+
+    // The returned string contains newly found repositories 
+    
+    let repos = scan_all(home_dir, &tracking_file, true).unwrap();
+
+    for n in 1..=3 {
+        assert!(repos.contains(
+            format!("{tests_dir}/repo{n}").as_str()
+        ));
+        assert!(repos.contains(
+            format!("{tests_dir}/.hidden/repo{n}").as_str()
+        ));
+    }
+}
+
+#[test]
+#[serial]
+fn case_scan_all_found_none() {
+    let (home_dir, mut tracking_file, _tests_dir) = common::setup().unwrap();
+
+    // Remove the tracking file if it already exists
+    if Path::new(tracking_file.path.as_str()).try_exists().unwrap() {
+        fs::remove_file(&tracking_file.path).unwrap();
+    }
+
+    // Create and populate the tracking file 
+    scan_all(home_dir.clone(), &tracking_file, true).unwrap();
+
+    // Update the tracking file contents
+    tracking_file.contents = fs::read_to_string(&tracking_file.path).unwrap();
+
+    // The returned string doesn't contain any repositories
+    assert!(scan_all(home_dir, &tracking_file, true).unwrap().is_empty());
+}


### PR DESCRIPTION
* **What kind of change does this PR introduce?**
Feature


* **What is the current behavior?**
`git-conform scan` does not inform the user about scanning results


* **What is the new behavior?**
`scan` command prints a list of found untracked repositories to the standard output, if none were found then it just informs the user


* **Does this PR introduce a breaking change?**
No


* **Other information**:
introduced the `--quiet` option for suppressing the messages